### PR TITLE
Patrickbkr add focusable role

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -21,6 +21,7 @@
     "Terminal::Widgets::ColorTheme": "lib/Terminal/Widgets/ColorTheme.rakumod",
     "Terminal::Widgets::ColorThemes": "lib/Terminal/Widgets/ColorThemes.rakumod",
     "Terminal::Widgets::Events": "lib/Terminal/Widgets/Events.rakumod",
+    "Terminal::Widgets::Focusable": "lib/Terminal/Widgets/Focusable.rakumod",
     "Terminal::Widgets::Form": "lib/Terminal/Widgets/Form.rakumod",
     "Terminal::Widgets::I18N::Locale": "lib/Terminal/Widgets/I18N/Locale.rakumod",
     "Terminal::Widgets::I18N::Translation": "lib/Terminal/Widgets/I18N/Translation.rakumod",

--- a/lib/Terminal/Widgets/Focusable.rakumod
+++ b/lib/Terminal/Widgets/Focusable.rakumod
@@ -1,0 +1,65 @@
+# ABSTRACT: Base role for widgets that can be focused / interacted with
+
+use Terminal::Widgets::Utils::Color;
+use Terminal::Widgets::ColorTheme;
+
+
+role Terminal::Widgets::Focusable {
+    has Bool:D $.enabled = True;
+    has        %.color;
+
+    has Terminal::Widgets::ColorSet:D $.colorset = self.terminal.colorset;
+
+
+    # Input-specific gist flags
+    method gist-flags() {
+       |callsame,
+       ('FOCUSED' if self.toplevel.focused-widget === self),
+       ('enabled' if $!enabled),
+    }
+
+    # Make sure unset colors are defaulted, and optionally add input to a form
+    method init-focusable() {
+        $!colorset .= clone(|%!color) if %!color;
+    }
+
+    #| Determine proper color based on state variables, taking care to handle
+    #| whatever color style mixtures have been requested
+    method current-color($states = self.current-color-states) {
+        $.colorset.current-color($states)
+    }
+
+    #| Determine current active states affecting color choices
+    method current-color-states() {
+        my $toplevel = self.toplevel;
+        my $terminal = $toplevel.terminal;
+        my $focused  = $toplevel.focused-widget === self;
+        my $blurred  = $focused && !($toplevel.is-current-toplevel &&
+                                     $terminal.terminal-focused);
+
+        my %states = :text, :input, :$focused, :$blurred,
+                     disabled => !$.enabled;
+    }
+
+    # Set enabled flag, then refresh
+    method set-enabled(Bool:D $!enabled = True) { self.full-refresh }
+    method toggle-enabled()                     { self.set-enabled(!$!enabled) }
+
+    # Move focus to next or previous Input
+    method focus-next-input() {
+        with self.next-widget(Terminal::Widgets::Focusable) {
+            self.toplevel.focus-on($_)
+        }
+        orwith self.toplevel.first-widget(Terminal::Widgets::Focusable) {
+            self.toplevel.focus-on($_)
+        }
+    }
+    method focus-prev-input() {
+        with self.prev-widget(Terminal::Widgets::Focusable) {
+            self.toplevel.focus-on($_)
+        }
+        orwith self.toplevel.last-widget(Terminal::Widgets::Focusable) {
+            self.toplevel.focus-on($_)
+        }
+    }
+}

--- a/lib/Terminal/Widgets/Input.rakumod
+++ b/lib/Terminal/Widgets/Input.rakumod
@@ -7,8 +7,7 @@ use Terminal::Widgets::Widget;
 use Terminal::Widgets::Form;
 
 
-role Terminal::Widgets::Input
-  is Terminal::Widgets::Widget {
+role Terminal::Widgets::Input {
     has Bool:D $.enabled = True;
     has Bool:D $!active  = False;   # XXXX: Handle this for all inputs?
     has        &.process-input;
@@ -91,13 +90,6 @@ role Terminal::Widgets::Input
     # Set enabled flag, then refresh
     method set-enabled(Bool:D $!enabled = True) { self.full-refresh }
     method toggle-enabled()                     { self.set-enabled(!$!enabled) }
-
-    # Convert animation drawing to full-refresh
-    method draw-frame() {
-        self.full-refresh;
-        # XXXX: Do we need to callsame here?
-        # callsame;
-    }
 
     # Move focus to next or previous Input
     method focus-next-input() {

--- a/lib/Terminal/Widgets/Input/Menu.rakumod
+++ b/lib/Terminal/Widgets/Input/Menu.rakumod
@@ -2,9 +2,11 @@
 
 use Terminal::Widgets::Events;
 use Terminal::Widgets::Input;
+use Terminal::Widgets::Widget;
 
 
 class Terminal::Widgets::Input::Menu
+ is Terminal::Widgets::Widget
  does Terminal::Widgets::Input {
     has UInt:D $.selected = 0;
     has UInt:D $.top-item = 0;

--- a/lib/Terminal/Widgets/Input/SimpleClickable.rakumod
+++ b/lib/Terminal/Widgets/Input/SimpleClickable.rakumod
@@ -4,10 +4,12 @@ use Terminal::Widgets::I18N::Translation;
 use Terminal::Widgets::Events;
 use Terminal::Widgets::Input;
 use Terminal::Widgets::Input::Labeled;
+use Terminal::Widgets::Widget;
 
 
 #| Base for labeled input widgets that can only be clicked/pressed/selected
 role Terminal::Widgets::Input::SimpleClickable
+is Terminal::Widgets::Widget
 does Terminal::Widgets::Input
 does Terminal::Widgets::Input::Labeled {
     # REQUIRED METHODS

--- a/lib/Terminal/Widgets/Input/Text.rakumod
+++ b/lib/Terminal/Widgets/Input/Text.rakumod
@@ -7,10 +7,12 @@ use Text::MiscUtils::Layout;
 use Terminal::Widgets::Utils::Color;
 use Terminal::Widgets::Events;
 use Terminal::Widgets::Input;
+use Terminal::Widgets::Widget;
 
 
 #| Single-line text entry field with history tracking and mappable keys
 class Terminal::Widgets::Input::Text
+ is Terminal::Widgets::Widget
  does Terminal::Widgets::Input
  does Terminal::LineEditor::HistoryTracking
  does Terminal::LineEditor::KeyMappable {
@@ -73,6 +75,13 @@ class Terminal::Widgets::Input::Text
         else {
             self.show-disabled(:$print);
         }
+    }
+
+    # Convert animation drawing to full-refresh
+    method draw-frame() {
+        self.full-refresh;
+        # XXXX: Do we need to callsame here?
+        # callsame;
     }
 
     #| Display input disabled state


### PR DESCRIPTION
Separate out a `Focusable` role from the `Input` role. Non-input widgets that still want to be able to have focus, can now use this new role.

One thing I don't like:

I had to move `submethod Focusable::TWEAK` to `method Focusable::init-focusable` as roles `does`ing from one another can't both provide identical methods. This unfortunately makes it necessary, that the doer of the `Focusable` role has to explicitly call the `init-focusable` method. I think this is so bad that we can't leave it like that, thus only a draft PR for now.